### PR TITLE
Troubleshoot run pca projected

### DIFF
--- a/create_pca_projection.json
+++ b/create_pca_projection.json
@@ -1,7 +1,7 @@
 {
-	"make_pca_projection.ref_bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/ref.bim",
-	"make_pca_projection.bed": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bed",
-	"make_pca_projection.bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bim",
-	"make_pca_projection.fam": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.fam",
-	"make_pca_projection.max_kinship_coefficient": 0.0884
+"make_pca_projection.ref_bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/ref.bim",
+"make_pca_projection.bed": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bed",
+"make_pca_projection.bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bim",
+"make_pca_projection.fam": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.fam",
+"make_pca_projection.max_kinship_coefficient": 0.0884
 }

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -176,7 +176,8 @@ task run_pca_projected {
 
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
-		command="/plink2 --bfile ${basename} \
+#		command="/plink2 --bed ${basename} \
+		command="/plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
 			--extract ~{keep_vars} \
 			--read-freq ~{freq_file} \
 			--score ~{loadings} 2 5 header-read no-mean-imputation variance-standardize \
@@ -253,9 +254,12 @@ workflow make_pca_projection {
 
 	call run_pca_projected {
 		input:
-			bed = extractOverlap.subset_bed, #might be able to just send the original .bed file here
-			bim = extractOverlap.subset_bim,
-			fam = extractOverlap.subset_fam,
+#			bed = extractOverlap.subset_bed, #might be able to just send the original .bed file here
+#			bim = extractOverlap.subset_bim,
+#			fam = extractOverlap.subset_fam,
+			bed = bed,
+			bim = bim, 
+			fam = fam,
 			keep_vars = pruneVars.subset_keep_vars,
 			loadings = make_pca_loadings.snp_loadings,
 			freq_file = make_pca_loadings.var_freq_counts,


### PR DESCRIPTION
Split call to plink bfile to explicitly call bed, bim, and fam in run_pca_projected. Set run_pca_projected to use unfiltered plink files as input.