### PR TITLE
Optional steps

### DIFF
--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -280,6 +280,14 @@ workflow create_pca_projection {
 			#n_cpus = n_cpus
 	}
 
+	output {
+		File var_freq_counts = make_pca_loadings.var_freq_counts
+		File snp_loadings =  make_pca_loadings.snp_loadings
+		File loadings_log =  make_pca_loadings.projection_log
+		File pca_projection = run_pca_projected.pca_projection
+		File projection_log = run_pca_projected.projection_log
+	}
+
 	meta {
 		author: "Jonathan Shortt"
 		email: "jonathan.shortt@cuanschutz.edu"

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -10,7 +10,7 @@ task removeRelateds {
 		Int mem_gb = 8
 	}
 
-	Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
+	#Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
 	String basename = basename(bed, ".bed")
 
 	command <<<
@@ -50,7 +50,7 @@ task extractOverlap {
 		Int mem_gb = 8
 	}
 
-	Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
+	#Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
 	String basename = basename(bed, ".bed")
 
 	command <<<
@@ -95,7 +95,7 @@ task pruneVars {
 		Int mem_gb = 8
 	}
 
-	Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
+	#Float disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB"))) * 1.5	#hoping this works?
 	String basename = basename(bed, ".bed")
 	
 	command <<<
@@ -128,7 +128,7 @@ task make_pca_loadings {
 		File keep_vars
 	}
 
-	Int disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB")))
+	#Int disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB")))
 	String basename = basename(bed, ".bed")
 	#ln --symbolic ${P} ${basename}.${k}.P.in
 
@@ -170,7 +170,7 @@ task run_pca_projected {
 		File freq_file
 	}
 
-	Int disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB")))
+	#Int disk_size = ceil(1.5*(size(bed, "GB") + size(bim, "GB") + size(fam, "GB")))
 	String basename = basename(bed, ".bed")
 
 	command <<<
@@ -211,8 +211,8 @@ workflow create_pca_projection {
 		Int? window_size
 		Int? shift_size
 		Int? r2_threshold
-		String? mem_gb
-		Int? n_cpus
+		#String? mem_gb
+		#Int? n_cpus
 	}
 
 	call removeRelateds {

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -242,8 +242,8 @@ workflow create_pca_projection {
 		input:
 			ref_bim = ref_bim,
 			bed = select_first([removeRelateds.out_bed, bed]),
-			bim = select_first([removeRelateds.out_bim, fam]),
-			fam = select_first([removeRelateds.out_bim, fam]),
+			bim = select_first([removeRelateds.out_bim, bim]),
+			fam = select_first([removeRelateds.out_fam, fam])
 	}
 
 	if (prune_variants) {

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -6,7 +6,7 @@ task removeRelateds {
 		File bed
 		File bim
 		File fam
-		Float? max_kinship_coefficient
+		Float max_kinship_coefficient = 0.0442
 		Int mem_gb = 8
 	}
 
@@ -23,7 +23,7 @@ task removeRelateds {
 
 		#identify individuals who are less related than kinship threshold
 		command="/plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-		~{if defined(max_kinship_coefficient) then "--king-cutoff ref_kin ~{max_kinship_coefficient}" else "--king-cutoff ref_kin 0.0442"} \
+		--king-cutoff ref_kin ~{max_kinship_coefficient} \
 		--out ~{basename}"
 		printf "${command}\n"
 		${command}
@@ -89,9 +89,9 @@ task pruneVars {
 		File bim
 		File fam
 		File keep_inds
-		Int? window_size
-		Int? shift_size
-		Int? r2_threshold
+		Int window_size = 10000
+		Int shift_size = 1000
+		Float r2_threshold = 0.1
 		Int mem_gb = 8
 	}
 
@@ -102,7 +102,7 @@ task pruneVars {
 		command="/plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
 			--keep ~{keep_inds} \
 			--keep-allele-order \
-			--indep-pairwise ~{if defined(window_size) then "~{window_size} ~{shift_size} ~{r2_threshold}" else "10000 1000 0.1"} \
+			--indep-pairwise ~{window_size} ~{shift_size} ~{r2_threshold} \
 			--out ~{basename}_indep"
 		printf "${command}\n"
 		${command}


### PR DESCRIPTION
Make both removeRelateds and pruneVariants optional in case we start with files where those steps have already been done. Confirmed that [output of this branch](https://anvil.terra.bio/#workspaces/primed-dev/PRIMED_ancestry-pipeline_devel/job_history/01b516dd-d314-46ca-a5c3-d0b3ad4f00c3) matches [last run of the main branch](https://anvil.terra.bio/#workspaces/primed-dev/PRIMED_ancestry-pipeline_devel/job_history/5c940ca9-08e3-47a4-8086-c91d5d157ad1).