### PR TITLE
Vcf input

### DIFF
--- a/create_pca_projection.json
+++ b/create_pca_projection.json
@@ -1,7 +1,27 @@
 {
-"make_pca_projection.ref_bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/ref.bim",
-"make_pca_projection.bed": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bed",
-"make_pca_projection.bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.bim",
-"make_pca_projection.fam": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/testing/projected_admixture_files/test.fam",
-"make_pca_projection.max_kinship_coefficient": 0.0884
+    "create_pca_projection.ref_variants": "gs://fc-0c05ad53-4513-482a-8f92-c3d0004f72bc/phase3_2504_samples/all_phase3_ns.pvar",
+    "create_pca_projection.vcf": [
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz"
+    ]
 }

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -2,6 +2,111 @@ version 1.0
 
 import "projected_pca.wdl" as tasks
 
+workflow create_pca_projection {
+	input{ 
+		Array[File] vcf
+		File ref_variants
+    	Boolean prune_variants = true
+   	 	Boolean remove_relateds = true
+		Float? max_kinship_coefficient
+		Int? window_size
+		Int? shift_size
+		Int? r2_threshold
+	}
+
+	call identifyColumns {
+		input:
+			ref_variants = ref_variants
+	}
+
+	scatter (file in vcf) {
+		call tasks.subsetVariants {
+			input:
+				vcf = file,
+				variant_file = ref_variants,
+				variant_id_col = identifyColumns.id_col
+		}
+
+		if (prune_variants) {
+			call pruneVars {
+				input:
+					pgen = subsetVariants.subset_pgen,
+					pvar = subsetVariants.subset_pvar,
+					psam = subsetVariants.subset_psam,
+					window_size = window_size,
+					shift_size = shift_size,
+					r2_threshold = r2_threshold
+			}
+		}
+
+		File subset_pgen = select_first([pruneVars.out_pgen, subsetVariants.subset_pgen])
+		File subset_pvar = select_first([pruneVars.out_pvar, subsetVariants.subset_pvar])
+		File subset_psam = select_first([pruneVars.out_psam, subsetVariants.subset_psam])
+	}
+
+	if (length(vcf) > 1) {
+		call tasks.mergeFiles {
+			input:
+				pgen = subset_pgen,
+				pvar = subset_pvar,
+				psam = subset_psam
+		}
+	}
+
+	File merged_pgen = select_first([mergeFiles.out_pgen, pruneVars.out_pgen[0], subsetVariants.subset_pgen[0]])
+	File merged_pvar = select_first([mergeFiles.out_pvar, pruneVars.out_pvar[0], subsetVariants.subset_pvar[0]])
+	File merged_psam = select_first([mergeFiles.out_psam, pruneVars.out_psam[0], subsetVariants.subset_psam[0]])
+
+  	if (remove_relateds) {
+		call removeRelateds {
+			input:
+				pgen = merged_pgen,
+				pvar = merged_pvar,
+				psam = merged_psam,
+				max_kinship_coefficient = max_kinship_coefficient
+		}
+	}
+
+	File final_pgen = select_first([removeRelateds.out_pgen, merged_pgen])
+	File final_pvar = select_first([removeRelateds.out_pvar, merged_pvar])
+	File final_psam = select_first([removeRelateds.out_psam, merged_psam])	
+
+	call make_pca_loadings {
+		input:
+			pgen = final_pgen,
+			pvar = final_pvar,
+			psam = final_psam
+	}
+
+	call tasks.run_pca_projected {
+		input:
+			pgen = merged_pgen,
+			pvar = merged_pvar,
+			psam = merged_psam,
+			loadings = make_pca_loadings.snp_loadings,
+			freq_file = make_pca_loadings.var_freq_counts,
+			id_col = 2,
+			allele_col = 5,
+			pc_col_first = 6,
+			pc_col_last = 15
+	}
+
+	output {
+		File var_freq_counts = make_pca_loadings.var_freq_counts
+		File snp_loadings =  make_pca_loadings.snp_loadings
+		File loadings_log =  make_pca_loadings.projection_log
+		File pca_projection = run_pca_projected.projection_file
+		File projection_log = run_pca_projected.projection_log
+	}
+
+	meta {
+		author: "Jonathan Shortt, Stephanie Gogarten"
+		email: "jonathan.shortt@cuanschutz.edu"
+		description: "This workflow is used to create a pca projection from a genetic reference dataset (in VCF format). First, the reference data is subsetted to include only sites in common with a provided reference variant file (intended to contain only variants that one would expect to find in all downstream datsets that will be projected using loadings created in this worflow (e.g., a list of common sites that are easily imputed in TOPMed)), and then pruned for linkage equilibrium. The related individuals are removed. Then PCA is run on the dataset."
+	}
+}
+
+
 task identifyColumns {
 	input {
 		File ref_variants
@@ -140,110 +245,5 @@ task make_pca_loadings {
 		File var_freq_counts = "~{basename}_snp_loadings.acount"
 		File snp_loadings = "~{basename}_snp_loadings.eigenvec.allele" 
 		File projection_log = "~{basename}_snp_loadings.log"
-	}
-}
-
-
-workflow create_pca_projection {
-	input{ 
-		Array[File] vcf
-		File ref_variants
-    	Boolean prune_variants = true
-   	 	Boolean remove_relateds = true
-		Float? max_kinship_coefficient
-		Int? window_size
-		Int? shift_size
-		Int? r2_threshold
-	}
-
-	call identifyColumns {
-		input:
-			ref_variants = ref_variants
-	}
-
-	scatter (file in vcf) {
-		call tasks.subsetVariants {
-			input:
-				vcf = file,
-				variant_file = ref_variants,
-				variant_id_col = identifyColumns.id_col
-		}
-
-		if (prune_variants) {
-			call pruneVars {
-				input:
-					pgen = subsetVariants.subset_pgen,
-					pvar = subsetVariants.subset_pvar,
-					psam = subsetVariants.subset_psam,
-					window_size = window_size,
-					shift_size = shift_size,
-					r2_threshold = r2_threshold
-			}
-		}
-
-		File subset_pgen = select_first([pruneVars.out_pgen, subsetVariants.subset_pgen])
-		File subset_pvar = select_first([pruneVars.out_pvar, subsetVariants.subset_pvar])
-		File subset_psam = select_first([pruneVars.out_psam, subsetVariants.subset_psam])
-	}
-
-	if (length(vcf) > 1) {
-		call tasks.mergeFiles {
-			input:
-				pgen = subset_pgen,
-				pvar = subset_pvar,
-				psam = subset_psam
-		}
-	}
-
-	File merged_pgen = select_first([mergeFiles.out_pgen, pruneVars.out_pgen[0], subsetVariants.subset_pgen[0]])
-	File merged_pvar = select_first([mergeFiles.out_pvar, pruneVars.out_pvar[0], subsetVariants.subset_pvar[0]])
-	File merged_psam = select_first([mergeFiles.out_psam, pruneVars.out_psam[0], subsetVariants.subset_psam[0]])
-
-  	if (remove_relateds) {
-		call removeRelateds {
-			input:
-				pgen = merged_pgen,
-				pvar = merged_pvar,
-				psam = merged_psam,
-				max_kinship_coefficient = max_kinship_coefficient
-		}
-	}
-
-	File final_pgen = select_first([removeRelateds.out_pgen, merged_pgen])
-	File final_pvar = select_first([removeRelateds.out_pvar, merged_pvar])
-	File final_psam = select_first([removeRelateds.out_psam, merged_psam])	
-
-	call make_pca_loadings {
-		input:
-			pgen = final_pgen,
-			pvar = final_pvar,
-			psam = final_psam
-	}
-
-	call tasks.run_pca_projected {
-		input:
-			pgen = merged_pgen,
-			pvar = merged_pvar,
-			psam = merged_psam,
-			loadings = make_pca_loadings.snp_loadings,
-			freq_file = make_pca_loadings.var_freq_counts,
-			id_col = 2,
-			allele_col = 5,
-			pc_col_first = 6,
-			pc_col_last = 15
-	}
-
-	output {
-		File var_freq_counts = make_pca_loadings.var_freq_counts
-		File snp_loadings =  make_pca_loadings.snp_loadings
-		File loadings_log =  make_pca_loadings.projection_log
-		File pca_projection = run_pca_projected.projection_file
-		File projection_log = run_pca_projected.projection_log
-	}
-
-	meta {
-		author: "Jonathan Shortt, Stephanie Gogarten"
-		email: "jonathan.shortt@cuanschutz.edu"
-		description: "This workflow is used to create a pca projection from a genetic reference dataset (in VCF format). First, the reference data is subsetted to include only sites in common with a provided reference variant file (intended to contain only variants that one would expect to find in all downstream datsets that will be projected using loadings created in this worflow (e.g., a list of common sites that are easily imputed in TOPMed)), and then pruned for linkage equilibrium. The related individuals are removed. Then PCA is run on the dataset."
 	}
 }

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -148,9 +148,9 @@ workflow create_pca_projection {
 	input{ 
 		Array[File] vcf
 		File ref_variants
+    	Boolean prune_variants = true
    	 	Boolean remove_relateds = true
 		Float? max_kinship_coefficient
-    	Boolean prune_variants = true
 		Int? window_size
 		Int? shift_size
 		Int? r2_threshold

--- a/projected_pca.json
+++ b/projected_pca.json
@@ -1,7 +1,28 @@
 {
-    "pca_projection.ref_loadings": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/submissions/5c940ca9-08e3-47a4-8086-c91d5d157ad1/create_pca_projection/3bc2f900-1441-4a00-a806-997981cb183c/call-make_pca_loadings/cacheCopy/hgdp_tgp_gnomad_v3.1.2.merged_snp_loadings.eigenvec.allele",
-    "pca_projection.ref_freqs": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/submissions/5c940ca9-08e3-47a4-8086-c91d5d157ad1/create_pca_projection/3bc2f900-1441-4a00-a806-997981cb183c/call-make_pca_loadings/cacheCopy/hgdp_tgp_gnomad_v3.1.2.merged_snp_loadings.acount",
-    "pca_projection.bed": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/hgdp_tgp_gnomad_v3.1.2/hgdp_tgp_gnomad_v3.1.2.merged.bed",
-    "pca_projection.bim": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/hgdp_tgp_gnomad_v3.1.2/hgdp_tgp_gnomad_v3.1.2.merged.vars_renamed.bim",
-    "pca_projection.fam": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/hgdp_tgp_gnomad_v3.1.2/hgdp_tgp_gnomad_v3.1.2.merged.fam"
+    "projected_PCA.ref_loadings": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/submissions/5c940ca9-08e3-47a4-8086-c91d5d157ad1/create_pca_projection/3bc2f900-1441-4a00-a806-997981cb183c/call-make_pca_loadings/cacheCopy/hgdp_tgp_gnomad_v3.1.2.merged_snp_loadings.eigenvec.allele",
+    "projected_PCA.ref_freqs": "gs://fc-077a4a13-7468-47d9-9c9c-7ec0559d1402/submissions/5c940ca9-08e3-47a4-8086-c91d5d157ad1/create_pca_projection/3bc2f900-1441-4a00-a806-997981cb183c/call-make_pca_loadings/cacheCopy/hgdp_tgp_gnomad_v3.1.2.merged_snp_loadings.acount",
+    "projected_PCA.vcf": [
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr1.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr2.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr3.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr4.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr5.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr6.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr7.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr8.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr9.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr10.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr11.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr12.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr13.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr14.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr15.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr16.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr17.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr18.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr19.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr20.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr21.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz",
+        "gs://terra-featured-workspaces/GWAS/1kg-genotypes/vcf/ALL.chr22.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.bgz"
+    ]
 }

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -6,8 +6,6 @@ workflow projected_PCA {
 		File ref_freqs
 		File vcf
 		Float overlap = 0.95
-		Int? mem_gb
-		Int? n_cpus
 	}
 
 	call prepareFiles {
@@ -30,9 +28,7 @@ workflow projected_PCA {
 				pvar = prepareFiles.subset_pvar,
 				psam = prepareFiles.subset_psam,
 				loadings = prepareFiles.subset_loadings,
-				freq_file = prepareFiles.subset_freqs,
-				mem_gb = mem_gb,
-				n_cpus = n_cpus
+				freq_file = prepareFiles.subset_freqs
 		}
 	}
 
@@ -58,10 +54,6 @@ task prepareFiles {
 
 	Int disk_size = ceil(2.5*(size(vcf, "GB")))
 	String filename = basename(vcf)
-	String b1 = sub(filename, "bcf", "")
-	String b2 = sub(filename, ".bcf", "")
-	String v1 = sub(filename, "vcf.gz", "")
-	String v2 = sub(filename, ".vcf.gz", "")
 	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
 	String prefix = if (sub(filename, ".bcf", "") != filename) then "--bcf" else "--vcf"
 
@@ -104,7 +96,6 @@ task checkOverlap {
 	input {
 		File ref_loadings
 		File pca_loadings
-		Int mem_gb = 8
 	}
 
 	command <<<
@@ -131,7 +122,6 @@ task checkOverlap {
 
 	runtime {
 		docker: "us.gcr.io/broad-dsp-gcr-public/base/python:3.9-debian"
-		memory: mem_gb + " GB"
 	}
 }
 

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -22,17 +22,15 @@ workflow projected_PCA {
 			pgen = prepareFiles.subset_pgen,
 			pvar = prepareFiles.subset_pvar,
 			psam = prepareFiles.subset_psam
-			#loadings = prepareFiles.subset_loadings,
-			#freqs = prepareFiles.subset_freqs
 	}
 
 	call checkOverlap {
 		input:
 			ref_loadings = ref_loadings,
 			pvar = mergeFiles.out_pvar
-			#pca_loadings = mergeFiles.out_loadings
 	}
 
+	#check for overlap, if overlap is less than threshold, stop
 	if (checkOverlap.overlap >= min_overlap) {
 		call run_pca_projected {
 			input:
@@ -72,23 +70,11 @@ task prepareFiles {
 
 	command <<<
 		#get a list of variant names in common between the two, save to extract.txt
-		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
-		#awk '{print $2}' ~{ref_loadings} > extract.txt
 		IDCOL=$(head -n1 ~{ref_loadings} | tr "\t" "\n" | grep -n ID | cut -d ":" -f1)
 		cut -f $IDCOL ~{ref_loadings} > extract.txt
 		#subset file with --extract extract.txt
 		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
 		awk '/^[^#]/ {print $3}' ~{basename}_pcaReady.pvar > selected_variants.txt
-
-		#extract variants in-common variants from ref_loadings
-		#this step may not be necessary at all since plink --score might just be able to deal with it
-		#head -n 1 ~{ref_loadings} > loadings_pcaReady.txt
-		#awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' selected_variants.txt ~{ref_loadings} >> loadings_pcaReady.txt
-
-		#extract variants in-common variants from ref_freqs
-		#this step may not be necessary at all since plink --score might just be able to deal with it
-		#head -n 1 ~{ref_freqs} > freqs_pcaReady.txt
-		#awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' selected_variants.txt ~{ref_freqs} >> freqs_pcaReady.txt
 	>>>
 
 	output {
@@ -97,8 +83,6 @@ task prepareFiles {
 		File subset_pvar="~{basename}_pcaReady.pvar"
 		File subset_psam="~{basename}_pcaReady.psam"
 		File subset_log="~{basename}_pcaReady.log"
-		#File subset_loadings="loadings_pcaReady.txt"
-		#File subset_freqs="freqs_pcaReady.txt"
 	}
 
 	runtime {
@@ -114,8 +98,6 @@ task mergeFiles {
 		Array[File] pgen
 		Array[File] pvar
 		Array[File] psam
-		#Array[File] loadings
-		#Array[File] freqs
 		Int mem_gb = 16
 	}
 
@@ -127,19 +109,10 @@ task mergeFiles {
 		/plink2 --pmerge-list pfile.txt --out merged
 	>>>
 
-		# concatenate loadings
-		#head -n 1 ~{loadings[1]} > merged_loadings.txt
-		#tail -n +2 -q ~{sep=' ' loadings} >> merged_loadings.txt
-		# concatenate freqs
-		#head -n 1 ~{freqs[1]} > merged_freqs.txt
-		#tail -n +2 -q ~{sep=' ' freqs} >> merged_freqs.txt
-
 	output {
 		File out_pgen = "merged.pgen"
 		File out_pvar = "merged.pvar"
 		File out_psam = "merged.psam"
-		#File out_loadings = "merged_loadings.txt"
-		#File out_freqs = "merged_freqs.txt"
 	}
 
 	runtime {
@@ -173,8 +146,6 @@ task checkOverlap {
 		CODE
 	>>>
 
-	#check for overlap, if overlap is less than threshold, stop, default overlap threshold is 0.95
-
 	output {
 		Float overlap = read_float(stdout())
 	}
@@ -192,12 +163,11 @@ task run_pca_projected {
 		File loadings
 		File freq_file
 		Int mem_gb = 8
-		Int n_cpus = 4 # check this
+		Int n_cpus = 4
 	}
 
 	Int disk_size = ceil(1.5*(size(pgen, "GB") + size(pvar, "GB") + size(psam, "GB")))
 	String basename = basename(pgen, ".pgen")
-	#ln --symbolic ${P} ${basename}.${k}.P.in
 
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
@@ -218,7 +188,6 @@ task run_pca_projected {
 	}
 
 	output {
-		#check output file name from --score in plink2
 		File projection_file = "~{basename}_proj_pca.sscore"
 		File projection_log = "~{basename}_proj_pca.log"
 	}

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -5,7 +5,7 @@ workflow projected_PCA {
 		File ref_loadings
 		File ref_freqs
 		Array[File] vcf
-		Float overlap = 0.95
+		Float min_overlap = 0.95
 	}
 
 	scatter (file in vcf) {
@@ -33,7 +33,7 @@ workflow projected_PCA {
 			#pca_loadings = mergeFiles.out_loadings
 	}
 
-	if (checkOverlap.overlap >= overlap) {
+	if (checkOverlap.overlap >= min_overlap) {
 		call run_pca_projected {
 			input:
 				pgen = mergeFiles.out_pgen,
@@ -47,6 +47,7 @@ workflow projected_PCA {
 	output {
 		File? projection_file = run_pca_projected.projection_file
 		File? projection_log = run_pca_projected.projection_log
+		Float overlap = checkOverlap.overlap
 	}
 
 	meta {

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -62,8 +62,8 @@ task prepareFiles {
 	String b2 = sub(filename, ".bcf", "")
 	String v1 = sub(filename, "vcf.gz", "")
 	String v2 = sub(filename, ".vcf.gz", "")
-	String basename = if (sub(filename, "bcf", "") == filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
-	String in_file = if (sub(filename, "bcf", "") == filename) then "--bcf" + basename else "--vcf " + basename
+	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
+	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf" + basename else "--vcf " + basename
 
 	command <<<
 		echo '~{filename}'

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -72,7 +72,9 @@ task prepareFiles {
 	command <<<
 		#get a list of variant names in common between the two, save to extract.txt
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
-		awk '{print $2}' ~{ref_loadings} > extract.txt
+		#awk '{print $2}' ~{ref_loadings} > extract.txt
+		IDCOL=$(head -n1 ~{ref_loadings} | tr "\t" "\n" | grep -n ID | cut -d ":" -f1)
+		cut -f $IDCOL > extract.txt
 		#subset file with --extract extract.txt
 		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
 		awk '/^[^#]/ {print $3}' ~{basename}_pcaReady.pvar > selected_variants.txt

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -63,7 +63,7 @@ task prepareFiles {
 	String v1 = sub(filename, "vcf.gz", "")
 	String v2 = sub(filename, ".vcf.gz", "")
 	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
-	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf" + basename else "--vcf " + basename
+	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf " + filename else "--vcf " + filename
 
 	command <<<
 		echo '~{filename}'

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -162,7 +162,7 @@ task checkOverlap {
 		
 		loadings_count=countLines("~{ref_loadings}")
 		new_loadings_count=countLines("~{pca_loadings}")
-		proportion=float(loadings_count)/new_loadings_count
+		proportion=float(new_loadings_count)/loadings_count
 		print("%.3f" % proportion)
 		CODE
 	>>>

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -31,9 +31,9 @@ workflow projected_PCA {
 		}
 	}
 
-	File final_pgen = select_first([mergeFiles.out_pgen, prepareFiles.subset_pgen[1]])
-	File final_pvar = select_first([mergeFiles.out_pvar, prepareFiles.subset_pvar[1]])
-	File final_psam = select_first([mergeFiles.out_psam, prepareFiles.subset_psam[1]])
+	File final_pgen = select_first([mergeFiles.out_pgen, prepareFiles.subset_pgen[0]])
+	File final_pvar = select_first([mergeFiles.out_pvar, prepareFiles.subset_pvar[0]])
+	File final_psam = select_first([mergeFiles.out_psam, prepareFiles.subset_psam[0]])
 
 	call checkOverlap {
 		input:

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -58,10 +58,11 @@ task prepareFiles {
 
 	Int disk_size = ceil(2.5*(size(vcf, "GB")))
 	String filename = basename(vcf)
-	String basename = if (sub(filename, ".bcf", "") == filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
-	String in_file = if (sub(filename, ".bcf", "") == filename) then "--bcf" + basename else "--vcf " + basename
+	String basename = if (sub(filename, "bcf", "") == filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
+	String in_file = if (sub(filename, "bcf", "") == filename) then "--bcf" + basename else "--vcf " + basename
 
 	command <<<
+		echo '~{in_file}'
 		#get a list of variant names in common between the two, save to extract.txt
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
 		awk '{print $2}' ~{ref_loadings} > extract.txt

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -99,7 +99,7 @@ task prepareFiles {
 	}
 
 	runtime {
-		docker: "us.gcr.io/broad-dsde-methods/plink2_docker@sha256:4455bf22ada6769ef00ed0509b278130ed98b6172c91de69b5bc2045a60de124"
+		docker: "emosyne/plink2@sha256:195614c953e81da763661be20ef149be7d16b348cb68c5d54114e261aede1c92"
 		disks: "local-disk " + disk_size + " SSD"
 		memory: mem_gb + " GB"
 	}

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -74,20 +74,21 @@ task prepareFiles {
 		awk '{print $2}' ~{ref_loadings} > extract.txt
 		#subset file with --extract extract.txt
 		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
+		awk '{print $2}' ~{basename}_pcaReady.pvar > selected_variants.txt
 
 		#extract variants in-common variants from ref_loadings
 		#this step may not be necessary at all since plink --score might just be able to deal with it
 		head -n 1 ~{ref_loadings} > loadings_pcaReady.txt
-		awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' extract.txt ~{ref_loadings} >> loadings_pcaReady.txt
+		awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' selected_variants.txt ~{ref_loadings} >> loadings_pcaReady.txt
 
 		#extract variants in-common variants from ref_freqs
 		#this step may not be necessary at all since plink --score might just be able to deal with it
 		head -n 1 ~{ref_freqs} > freqs_pcaReady.txt
-		awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' extract.txt ~{ref_freqs} >> freqs_pcaReady.txt
+		awk 'FNR==NR{a[$1]; next}{if($2 in a) {print $0}}' selected_variants.txt ~{ref_freqs} >> freqs_pcaReady.txt
 	>>>
 
 	output {
-		File snps_to_keep="extract.txt"
+		File snps_to_keep="selected_variants.txt"
 		File subset_pgen="~{basename}_pcaReady.pgen"
 		File subset_pvar="~{basename}_pcaReady.pvar"
 		File subset_psam="~{basename}_pcaReady.psam"

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -74,7 +74,7 @@ task prepareFiles {
 		awk '{print $2}' ~{ref_loadings} > extract.txt
 		#subset file with --extract extract.txt
 		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
-		awk '{print $2}' ~{basename}_pcaReady.pvar > selected_variants.txt
+		awk '/^[^#]/ {print $3}' ~{basename}_pcaReady.pvar > selected_variants.txt
 
 		#extract variants in-common variants from ref_loadings
 		#this step may not be necessary at all since plink --score might just be able to deal with it

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -28,7 +28,7 @@ workflow projected_PCA {
 			input:
 				pgen = prepareFiles.subset_pgen,
 				pvar = prepareFiles.subset_pvar,
-				pfam = prepareFiles.subset_pfam,
+				psam = prepareFiles.subset_psam,
 				loadings = prepareFiles.subset_loadings,
 				freq_file = prepareFiles.subset_freqs,
 				mem_gb = mem_gb,
@@ -87,7 +87,7 @@ task prepareFiles {
 		File snps_to_keep="extract.txt"
 		File subset_pgen="~{basename}_pcaReady.pgen"
 		File subset_pvar="~{basename}_pcaReady.pvar"
-		File subset_pfam="~{basename}_pcaReady.pfam"
+		File subset_psam="~{basename}_pcaReady.psam"
 		File subset_log="~{basename}_pcaReady.log"
 		File subset_loadings="loadings_pcaReady.txt"
 		File subset_freqs="freqs_pcaReady.txt"
@@ -139,20 +139,20 @@ task run_pca_projected {
 	input {
 		File pgen
 		File pvar
-		File pfam
+		File psam
 		File loadings
 		File freq_file
 		Int mem_gb = 8
 		Int n_cpus = 4 # check this
 	}
 
-	Int disk_size = ceil(1.5*(size(pgen, "GB") + size(pvar, "GB") + size(pfam, "GB")))
+	Int disk_size = ceil(1.5*(size(pgen, "GB") + size(pvar, "GB") + size(psam, "GB")))
 	String basename = basename(pgen, ".pgen")
 	#ln --symbolic ${P} ${basename}.${k}.P.in
 
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
-		command="/plink2 --pgen ~{pgen} --pvar ~{pvar} --pfam ~{pfam} \
+		command="/plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
 			--read-freq ~{freq_file} \
 			--score ~{loadings} 2 5 header-read no-mean-imputation variance-standardize \
 			--score-col-nums 6-15 \

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -72,7 +72,7 @@ task identifyColumns {
 
 	command <<<
 		Rscript -e "\
-		dat <- readr::read_tsv('~(ref_loadings}')
+		dat <- readr::read_tsv('~{ref_loadings}')
 		writeLines(as.character(which(names(dat) == 'ID')), 'id_col.txt')
 		if (is.element('A1', names(dat))) allele_col <- 'A1' else allele_col <- 'ALT'
 		writeLines(as.character(which(names(dat) == allele_col)), 'allele_col.txt')

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -63,14 +63,14 @@ task prepareFiles {
 	String v1 = sub(filename, "vcf.gz", "")
 	String v2 = sub(filename, ".vcf.gz", "")
 	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
-	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf " + vcf else "--vcf " + vcf
+	String prefix = if (sub(filename, ".bcf", "") != filename) then "--bcf" else "--vcf"
 
 	command <<<
 		#get a list of variant names in common between the two, save to extract.txt
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
 		awk '{print $2}' ~{ref_loadings} > extract.txt
 		#subset file with --extract extract.txt
-		/plink2 ~{in_file} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
+		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
 
 		#extract variants in-common variants from ref_loadings
 		#this step may not be necessary at all since plink --score might just be able to deal with it

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -74,7 +74,7 @@ task prepareFiles {
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
 		#awk '{print $2}' ~{ref_loadings} > extract.txt
 		IDCOL=$(head -n1 ~{ref_loadings} | tr "\t" "\n" | grep -n ID | cut -d ":" -f1)
-		cut -f $IDCOL > extract.txt
+		cut -f $IDCOL ~{ref_loadings} > extract.txt
 		#subset file with --extract extract.txt
 		/plink2 ~{prefix} ~{vcf} --extract extract.txt --make-pgen --out ~{basename}_pcaReady
 		awk '/^[^#]/ {print $3}' ~{basename}_pcaReady.pvar > selected_variants.txt

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -121,11 +121,11 @@ task mergeFiles {
 		cat ~{write_lines(pgen)} | sed 's/.pgen//' > pfile.txt
 		/plink2 --pmerge-list pfile.txt --out merged
 		# concatenate loadings
-		head -n 1 ~{loadings[1]} > loadings.txt
-		tail -n +2 -q ~{sep=' ' loadings} >> loadings.txt
+		head -n 1 ~{loadings[1]} > merged_loadings.txt
+		tail -n +2 -q ~{sep=' ' loadings} >> merged_loadings.txt
 		# concatenate freqs
-		head -n 1 ~{freqs[1]} > freqs.txt
-		tail -n +2 -q ~{sep=' ' freqs} >> freqs.txt
+		head -n 1 ~{freqs[1]} > merged_freqs.txt
+		tail -n +2 -q ~{sep=' ' freqs} >> merged_freqs.txt
 	>>>
 
 	output {

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -58,11 +58,19 @@ task prepareFiles {
 
 	Int disk_size = ceil(2.5*(size(vcf, "GB")))
 	String filename = basename(vcf)
+	String b1 = sub(filename, "bcf", "")
+	String b2 = sub(filename, ".bcf", "")
+	String v1 = sub(filename, "vcf.gz", "")
+	String v2 = sub(filename, ".vcf.gz", "")
 	String basename = if (sub(filename, "bcf", "") == filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
 	String in_file = if (sub(filename, "bcf", "") == filename) then "--bcf" + basename else "--vcf " + basename
 
 	command <<<
-		echo '~{in_file}'
+		echo '~{filename}'
+		echo '~{b1}'
+		echo '~{b2}'
+		echo '~{v1}'
+		echo '~{v2}'
 		#get a list of variant names in common between the two, save to extract.txt
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
 		awk '{print $2}' ~{ref_loadings} > extract.txt

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -63,14 +63,9 @@ task prepareFiles {
 	String v1 = sub(filename, "vcf.gz", "")
 	String v2 = sub(filename, ".vcf.gz", "")
 	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
-	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf " + filename else "--vcf " + filename
+	String in_file = if (sub(filename, ".bcf", "") != filename) then "--bcf " + vcf else "--vcf " + vcf
 
 	command <<<
-		echo '~{filename}'
-		echo '~{b1}'
-		echo '~{b2}'
-		echo '~{v1}'
-		echo '~{v2}'
 		#get a list of variant names in common between the two, save to extract.txt
 		#variant name in loadings is assumed to be 3rd column, assuming plink2 format (https://www.cog-genomics.org/plink/2.0/formats#eigenvec)
 		awk '{print $2}' ~{ref_loadings} > extract.txt

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -31,9 +31,9 @@ workflow projected_PCA {
 		}
 	}
 
-	File final_pgen = select_first([mergeFiles.out_pgen, prepareFiles.subset_pgen])
-	File final_pvar = select_first([mergeFiles.out_pvar, prepareFiles.subset_pvar])
-	File final_psam = select_first([mergeFiles.out_psam, prepareFiles.subset_psam])
+	File final_pgen = select_first([mergeFiles.out_pgen, prepareFiles.subset_pgen[1]])
+	File final_pvar = select_first([mergeFiles.out_pvar, prepareFiles.subset_pvar[1]])
+	File final_psam = select_first([mergeFiles.out_psam, prepareFiles.subset_psam[1]])
 
 	call checkOverlap {
 		input:


### PR DESCRIPTION
Since the PRIMED data model specifies genotype data in VCF format, and often VCF files are split by chromosome, this revision to the project PCA workflow allows an array of VCF input files. Each file is subset to the variants in ref_loadings, and then files are merged into a single .pgen file for running PCA.

Columns in the input ref loadings are identified by name instead of having position hard-coded, which allows more flexibility in input format. An additional task finds the column numbers and passes them to subsequent tasks.