### PR TITLE
Allow the user to specify which sample variants to use in projected_pca

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ ref_groups | Two-column tsv file of subject_id and group from reference dataset,
 groups_file | Two-column tsv file of subject_id and group from sample dataset, used to label plots (optional)
 vcf | Array of VCF files (possibly split by chromosome)
 min_overlap | minimum overlap between variants in loadings and vcf files (default 0.95). If the overlap is less than this threshold, PCA will not be run and the workflow will exit.
+sample_file | A file containing the set of sample ids to include (optional)
+variant_file | A file containing the set of variants to include in the projection. If passed, the intersection between variants in this file and in the reference panel will be used. (optional)
 
 
 Outputs:

--- a/create_pca_projection.wdl
+++ b/create_pca_projection.wdl
@@ -43,7 +43,7 @@ workflow create_pca_projection {
 		call variant_tasks.subsetVariants {
 			input:
 				vcf = file,
-				variant_file = identifyColumns.id_file,
+				variant_files = select_all([identifyColumns.id_file]),
 				sample_file = sample_file,
 				missingness_filter = missingness_filter,
 				genome_build = genome_build,

--- a/file_tasks.wdl
+++ b/file_tasks.wdl
@@ -6,6 +6,8 @@ task identifyColumns {
 		String id_column = "ID"
 	}
 
+	Int disk_size = ceil(2*(size(ref_variants, "GB"))) + 5
+
 	command <<<
 		Rscript -e "\
 		dat <- readr::read_tsv('~{ref_variants}', comment = '##', n_max=100); \
@@ -20,6 +22,7 @@ task identifyColumns {
 
 	runtime {
 		docker: "us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.17.0"
+		disks: "local-disk " + disk_size + " SSD"
 	}
 }
 

--- a/ld_pruning.wdl
+++ b/ld_pruning.wdl
@@ -19,7 +19,7 @@ workflow LD_pruning {
         call variant_tasks.subsetVariants {
              input:
                 vcf = file,
-                variant_file = variant_file,
+                variant_files = select_all([variant_file]),
                 genome_build = genome_build,
                 min_maf = min_maf,
                 snps_only = snps_only

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -12,6 +12,7 @@ workflow projected_PCA {
 		File? ref_pcs
 		File? ref_groups
 		File? sample_file
+		File? sample_variants_file
 		Float? missingness_filter
 		File? groups_file
 		Array[File] vcf
@@ -29,7 +30,7 @@ workflow projected_PCA {
 		call variant_tasks.subsetVariants {
 			input:
 				vcf = file,
-				variant_files = select_all([identifyColumns.id_file]),
+				variant_files = select_all([identifyColumns.id_file, sample_variants_file]),
 				sample_file = sample_file,
 				missingness_filter = missingness_filter,
 				genome_build = genome_build

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -29,7 +29,7 @@ workflow projected_PCA {
 		call variant_tasks.subsetVariants {
 			input:
 				vcf = file,
-				variant_file = identifyColumns.id_file,
+				variant_files = select_all([identifyColumns.id_file]),
 				sample_file = sample_file,
 				missingness_filter = missingness_filter,
 				genome_build = genome_build
@@ -69,8 +69,8 @@ workflow projected_PCA {
 	}
 
 	call pca_plots.run_pca_plots {
-		input: 
-			data_file = ProjectArray.projections, 
+		input:
+			data_file = ProjectArray.projections,
 			groups_file = groups_file
 	}
 
@@ -81,14 +81,14 @@ workflow projected_PCA {
 		File ref_pcs1 = select_first([ref_pcs, ""])
 
 		call concatenateFiles {
-			input: 
+			input:
 				ref_pcs = ref_pcs1,
 				ref_groups = ref_groups,
 				projection_file = ProjectArray.projections
 		}
 
 		call pca_plots.run_pca_plots as run_pca_plots_ref {
-			input: 
+			input:
 				data_file = concatenateFiles.merged_pcs,
 				groups_file = concatenateFiles.merged_groups,
 				colormap = concatenateFiles.colormap

--- a/projected_pca.wdl
+++ b/projected_pca.wdl
@@ -12,7 +12,7 @@ workflow projected_PCA {
 		File? ref_pcs
 		File? ref_groups
 		File? sample_file
-		File? sample_variants_file
+		File? variant_file
 		Float? missingness_filter
 		File? groups_file
 		Array[File] vcf
@@ -30,7 +30,7 @@ workflow projected_PCA {
 		call variant_tasks.subsetVariants {
 			input:
 				vcf = file,
-				variant_files = select_all([identifyColumns.id_file, sample_variants_file]),
+				variant_files = select_all([identifyColumns.id_file, variant_file]),
 				sample_file = sample_file,
 				missingness_filter = missingness_filter,
 				genome_build = genome_build

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -14,7 +14,7 @@ task subsetVariants {
 		Int mem_gb = 8
 	}
 
-	Int disk_size = ceil(2.5*(size(vcf, "GB"))) + 5
+	Int disk_size = ceil(2.5*(size(vcf, "GB") + size(variant_files, "GB"))) + 5
 	String filename = basename(vcf)
 	String basename = if (sub(filename, ".bcf", "") != filename) then basename(filename, ".bcf") else basename(filename, ".vcf.gz")
 	String prefix = if (sub(filename, ".bcf", "") != filename) then "--bcf" else "--vcf"

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -3,7 +3,7 @@ version 1.0
 task subsetVariants {
 	input {
 		File vcf
-		Array[File]? variant_files
+		Array[File] variant_files = []
 		File? sample_file
 		File? alt_allele_file
 		Float? min_maf
@@ -28,7 +28,7 @@ task subsetVariants {
 		plink2 \
 			~{prefix} ~{vcf} \
 			~{"--maf " + min_maf} \
-			~{if defined(variant_files) then "--extract-intersect " else ""} ~{sep=" " variant_files} \
+			~{if length(variant_files) > 0 then "--extract-intersect " else ""} ~{sep=" " variant_files} \
 			~{"--keep " + sample_file} \
 			~{"--geno " + missingness_filter} \
 			--exclude bed1 exclude.txt \

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -3,7 +3,7 @@ version 1.0
 task subsetVariants {
 	input {
 		File vcf
-		File? variant_file
+		Array[File]? variant_files
 		File? sample_file
 		File? alt_allele_file
 		Float? min_maf
@@ -28,7 +28,7 @@ task subsetVariants {
 		plink2 \
 			~{prefix} ~{vcf} \
 			~{"--maf " + min_maf} \
-			~{"--extract " + variant_file} \
+			~{if defined(variant_files) then "--extract-intersect " else ""} ~{sep=" " variant_files} \
 			~{"--keep " + sample_file} \
 			~{"--geno " + missingness_filter} \
 			--exclude bed1 exclude.txt \

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -25,7 +25,11 @@ task subsetVariants {
 		cut -f 1,2,3 exclude_b~{genome_build}.txt > exclude.txt
 
 		#subset file with --extract extract.txt
-		plink2 ~{prefix} ~{vcf} ~{"--maf " + min_maf} ~{"--extract " + variant_file} ~{"--keep " + sample_file} \
+		plink2 \
+			~{prefix} ~{vcf} \
+			~{"--maf " + min_maf} \
+			~{"--extract " + variant_file} \
+			~{"--keep " + sample_file} \
 			~{"--geno " + missingness_filter} \
 			--exclude bed1 exclude.txt \
 			~{true="--snps-only 'just-acgt' --max-alleles 2" false="" snps_only} \


### PR DESCRIPTION
- [x] Update `subsetVariants` to take an array of variant_files, instead of just one variant_file
- [x] Update WDLs using the `subsetVariants` task to pass arrays instead of single files for `variant_files`
- [x] Add a `variant_include` input to `projected_pca.wdl` and pass it to the `subsetVariants` task. This allows the user to provide a list of (study) variants that should be used when projecting onto PC space, in addition to the variants in ref_loadings. The use case is e.g. for including only PASS variants in the study sample.
- [x] Test workflow somehow
