### PR TITLE
Use explicit memory limit in PLINK

### DIFF
--- a/file_tasks.wdl
+++ b/file_tasks.wdl
@@ -45,9 +45,11 @@ task mergeFiles {
 		# merge plink files
 		cat ~{write_lines(bed)} | sed 's/\.bed$//' > bfile.txt
 		plink2 --pmerge-list bfile.txt bfile \
+      --memory ~{mem_gb *  1024} \
 			--merge-max-allele-ct 2 \
 			--out tmp
 		plink2 --pfile tmp \
+      --memory ~{mem_gb *  1024} \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
 			--make-bed --out merged \

--- a/file_tasks.wdl
+++ b/file_tasks.wdl
@@ -45,11 +45,11 @@ task mergeFiles {
 		# merge plink files
 		cat ~{write_lines(bed)} | sed 's/\.bed$//' > bfile.txt
 		plink2 --pmerge-list bfile.txt bfile \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--merge-max-allele-ct 2 \
 			--out tmp
 		plink2 --pfile tmp \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
 			--make-bed --out merged \

--- a/file_tasks.wdl
+++ b/file_tasks.wdl
@@ -45,11 +45,11 @@ task mergeFiles {
 		# merge plink files
 		cat ~{write_lines(bed)} | sed 's/\.bed$//' > bfile.txt
 		plink2 --pmerge-list bfile.txt bfile \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--merge-max-allele-ct 2 \
 			--out tmp
 		plink2 --pfile tmp \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
 			--make-bed --out merged \

--- a/maf_by_pop.wdl
+++ b/maf_by_pop.wdl
@@ -135,6 +135,7 @@ task maf_by_pop {
 
     command <<<
         plink2 ~{prefix} ~{vcf} \
+            --memory ~{mem_gb *  1024} \
             --keep ~{samples} \
             --maf ~{min_maf} \
             --output-chr chrM \

--- a/maf_by_pop.wdl
+++ b/maf_by_pop.wdl
@@ -135,7 +135,7 @@ task maf_by_pop {
 
     command <<<
         plink2 ~{prefix} ~{vcf} \
-            --memory ~{mem_gb *  1024} \
+            --memory ~{mem_gb *  512} \
             --keep ~{samples} \
             --maf ~{min_maf} \
             --output-chr chrM \

--- a/pca_tasks.wdl
+++ b/pca_tasks.wdl
@@ -14,6 +14,7 @@ task make_pca_loadings {
 
 	command <<<
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
+      --memory ~{mem_gb *  1024} \
 			--maf 0.000001 \
 			--freq counts \
 			--pca allele-wts \
@@ -60,6 +61,7 @@ task run_pca_projected {
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
+      --memory ~{mem_gb *  1024} \
 			--read-freq ~{freq_file} \
 			--score ~{loadings} ~{id_col} ~{allele_col} header-read no-mean-imputation variance-standardize \
 			--score-col-nums ~{pc_col_first}-~{pc_col_last} \

--- a/pca_tasks.wdl
+++ b/pca_tasks.wdl
@@ -14,7 +14,7 @@ task make_pca_loadings {
 
 	command <<<
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--maf 0.000001 \
 			--freq counts \
 			--pca allele-wts \
@@ -61,7 +61,7 @@ task run_pca_projected {
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--read-freq ~{freq_file} \
 			--score ~{loadings} ~{id_col} ~{allele_col} header-read no-mean-imputation variance-standardize \
 			--score-col-nums ~{pc_col_first}-~{pc_col_last} \

--- a/pca_tasks.wdl
+++ b/pca_tasks.wdl
@@ -14,7 +14,7 @@ task make_pca_loadings {
 
 	command <<<
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--maf 0.000001 \
 			--freq counts \
 			--pca allele-wts \
@@ -61,7 +61,7 @@ task run_pca_projected {
 	command <<<
 		#https://www.cog-genomics.org/plink/2.0/score#pca_project
 		command="plink2 --pgen ~{pgen} --pvar ~{pvar} --psam ~{psam} \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--read-freq ~{freq_file} \
 			--score ~{loadings} ~{id_col} ~{allele_col} header-read no-mean-imputation variance-standardize \
 			--score-col-nums ~{pc_col_first}-~{pc_col_last} \

--- a/sample_filtering.wdl
+++ b/sample_filtering.wdl
@@ -17,6 +17,7 @@ task removeRelateds {
     command <<<
         #identify individuals who are less related than kinship threshold
         command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
+        --memory ~{mem_gb *  1024} \
         --king-cutoff ~{max_kinship_coefficient} \
         --output-chr ~{output_chr} \
         --set-all-var-ids @:#:\$r:\$a \
@@ -59,6 +60,7 @@ task king_ibdseg {
         set -e -o pipefail
 
         plink --bed ~{bed} --bim ~{bim} --fam ~{fam} \
+            --memory ~{mem_gb *  1024} \
             --output-chr 26 \
             --make-bed --out tmp \
 

--- a/sample_filtering.wdl
+++ b/sample_filtering.wdl
@@ -17,7 +17,7 @@ task removeRelateds {
     command <<<
         #identify individuals who are less related than kinship threshold
         command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-        --memory ~{mem_gb *  1024} \
+        --memory ~{mem_gb *  512} \
         --king-cutoff ~{max_kinship_coefficient} \
         --output-chr ~{output_chr} \
         --set-all-var-ids @:#:\$r:\$a \
@@ -60,7 +60,7 @@ task king_ibdseg {
         set -e -o pipefail
 
         plink --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-            --memory ~{mem_gb *  1024} \
+            --memory ~{mem_gb *  512} \
             --output-chr 26 \
             --make-bed --out tmp \
 

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -27,6 +27,7 @@ task subsetVariants {
 
 		#subset file with --extract extract.txt
 		plink2 \
+      --memory ~{mem_gb *  1024} \
 			~{prefix} ~{vcf} \
 			~{"--maf " + min_maf} \
 			~{if length(variant_files) > 0 then "--extract-intersect " else ""} ~{sep=" " variant_files} \
@@ -81,6 +82,7 @@ task pruneVars {
 		set -e -o pipefail
 
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
+      --memory ~{mem_gb *  1024} \
 			--rm-dup force-first \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
@@ -91,6 +93,7 @@ task pruneVars {
 
 		# extract pruned variants
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
+      --memory ~{mem_gb *  1024} \
 			--extract ~{basename}_indep.prune.in \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -27,7 +27,7 @@ task subsetVariants {
 
 		#subset file with --extract extract.txt
 		plink2 \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			~{prefix} ~{vcf} \
 			~{"--maf " + min_maf} \
 			~{if length(variant_files) > 0 then "--extract-intersect " else ""} ~{sep=" " variant_files} \
@@ -82,7 +82,7 @@ task pruneVars {
 		set -e -o pipefail
 
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--rm-dup force-first \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
@@ -93,7 +93,7 @@ task pruneVars {
 
 		# extract pruned variants
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-			--memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  512} \
 			--extract ~{basename}_indep.prune.in \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -27,7 +27,7 @@ task subsetVariants {
 
 		#subset file with --extract extract.txt
 		plink2 \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			~{prefix} ~{vcf} \
 			~{"--maf " + min_maf} \
 			~{if length(variant_files) > 0 then "--extract-intersect " else ""} ~{sep=" " variant_files} \

--- a/variant_filtering.wdl
+++ b/variant_filtering.wdl
@@ -82,7 +82,7 @@ task pruneVars {
 		set -e -o pipefail
 
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--rm-dup force-first \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \
@@ -93,7 +93,7 @@ task pruneVars {
 
 		# extract pruned variants
 		command="plink2 --bed ~{bed} --bim ~{bim} --fam ~{fam} \
-      --memory ~{mem_gb *  1024} \
+			--memory ~{mem_gb *  1024} \
 			--extract ~{basename}_indep.prune.in \
 			--output-chr ~{output_chr} \
 			--set-all-var-ids @:#:\$r:\$a \


### PR DESCRIPTION
Previous behavior caused issues with HPCs. Specifically, PLINK detects all available RAM on system, leading to OOM when PLINK attempts to use more memory than is allocated by the job scheduler. Now allocates 1/2 of requested memory (mem_gb) to the PLINK process.